### PR TITLE
Enable many gpu72 options

### DIFF
--- a/mfloop.py
+++ b/mfloop.py
@@ -338,7 +338,7 @@ parser.add_option("-U", "--gpu72user", dest="guser", help="GPU72 user name", def
 parser.add_option("-P", "--gpu72pass", dest="gpass", help="GPU72 password")
 
 parser.add_option("-n", "--num_cache", dest="num_cache", default="1", help="Number of assignments to cache, default 1")
-parser.add_option("-g", "--ghzd_cache", dest="ghzd_cache", default="", help="GHz-days of assignments to cache beyond the first/current assignment in worktodo.txt. Overrides num_cache.")
+parser.add_option("-g", "--ghzd_cache", dest="ghzd_cache", default="", help="GHz-days of assignments to cache. Overrides num_cache.")
 
 parser.add_option("-t", "--timeout", dest="timeout", default="3600", help="Seconds to wait between network updates, default 3600. Use 0 for a single update without looping.")
 


### PR DESCRIPTION
Add support for:
- Fetching LLTF or DCTF work
- Fetching work by GHz-days instead of number of assignments
- Fetching work by what_makes_sense (default), lowest TF level, highest TF level, lowest exponent, oldest exponent, no P1 done (DCTF), LHM bit-first (LLTF), LHM depth-first (LLTF), and let GPU72 decide.
